### PR TITLE
Tests passing for valid addresses

### DIFF
--- a/bech32.js
+++ b/bech32.js
@@ -94,7 +94,7 @@ function decode (str) {
   }
 
   // NOTE: zero-fill required
-  let result = Buffer.alloc(bitData.length)
+  let result = Buffer.alloc(bitData.length - 6)
 
   for (let i = 0; i < bitData.length; ++i) {
     let cv = bitData.charCodeAt(i)

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function decode (expectedPrefix, string) {
   let result = bech32.decode(string)
   assert.equal(result.prefix, expectedPrefix)
 
-  assert((result.bitData.length > 0) && (result.bitData.length < 65))
+  assert((result.bitData.length > 0) && (result.bitData.length < 66))
   let version = result.bitData[0]
   let program = convertBits(result.bitData.slice(1), 5, 8, false)
   assert((program.length > 1) && (program.length < 41))
@@ -55,7 +55,7 @@ function decode (expectedPrefix, string) {
     assert((program.length === 20) || (program.length === 32))
   }
 
-  return { version, program }
+  return { version, program: Buffer.from(program) }
 }
 
 module.exports = { encode, decode }

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1,76 +1,84 @@
 {
-  "valid": [
-    {
-      "string": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
-      "prefix": "bc",
-      "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
-      "version": 0
-    },
-    {
-      "string": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
-      "prefix": "tb",
-      "hex": "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-      "version": 0
-    },
-    {
-      "string": "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
-      "prefix": "bc",
-      "hex": "751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
-      "version": 1
-    },
-    {
-      "string": "BC1SW50QA3JX3S",
-      "prefix": "bc",
-      "hex": "751e",
-      "version": 16
-    },
-    {
-      "string": "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
-      "prefix": "bc",
-      "hex": "751e76e8199196d454941c45d1b3a323",
-      "version": 2
-    },
-    {
-      "string": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
-      "prefix": "tb",
-      "hex": "000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-      "version": 0
-    },
-    {
-      "string": "A12UEL5L",
-      "prefix": "a",
-      "hex": ""
-    },
-    {
-      "string": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
-      "prefix": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
-      "hex": ""
-    },
-    {
-      "string": "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
-      "prefix": "abcdef",
-      "hex": "00443214c74254b635cf84653a56d7c675be77df"
-    },
-    {
-      "string": "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
-      "prefix": "1",
-      "hex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-    },
-    {
-      "string": "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
-      "prefix": "split",
-      "hex": "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d"
-    }
-  ],
-  "invalid": [
-    "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
-    "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-    "bc1rw5uspcuh",
-    "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
-    "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-    "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
-    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
-  ]
+  "addresses": {
+    "valid": [
+      {
+        "string": "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "version": 0
+      },
+      {
+        "string": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+        "prefix": "tb",
+        "hex": "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "version": 0
+      },
+      {
+        "string": "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+        "version": 1
+      },
+      {
+        "string": "BC1SW50QA3JX3S",
+        "prefix": "bc",
+        "hex": "751e",
+        "version": 16
+      },
+      {
+        "string": "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+        "prefix": "bc",
+        "hex": "751e76e8199196d454941c45d1b3a323",
+        "version": 2
+      },
+      {
+        "string": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+        "prefix": "tb",
+        "hex": "000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "version": 0
+      }
+    ],
+    "invalid": [
+      "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+      "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+      "bc1rw5uspcuh",
+      "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+      "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+      "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
+      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
+    ]
+  },
+  "bech32": {
+    "valid": [
+      {
+        "string": "A12UEL5L",
+        "prefix": "a",
+        "hex": ""
+      },
+      {
+        "string": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+        "prefix": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
+        "hex": ""
+      },
+      {
+        "string": "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+        "prefix": "abcdef",
+        "hex": "00443214c74254b635cf84653a56d7c675be77df"
+      },
+      {
+        "string": "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+        "prefix": "1",
+        "hex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      },
+      {
+        "string": "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+        "prefix": "split",
+        "hex": "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d"
+      }
+    ],
+    "invalid": [
+    ]
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,23 +2,23 @@ let tape = require('tape')
 let fixtures = require('./fixtures')
 let bech32 = require('../')
 
-fixtures.valid.forEach((f, i) => {
+fixtures.addresses.valid.forEach((f, i) => {
   // unlike the reference impl., we don't support mixed/uppercase
   let string = f.string.toLowerCase()
   let buffer = Buffer.from(f.hex, 'hex')
 
   tape('encode ' + string, (t) => {
     t.plan(1)
-    t.same(bech32.encode(f.prefix, buffer), string)
+    t.same(bech32.encode(f.prefix, f.version, buffer), string)
   })
 
   tape('decode ' + string, (t) => {
     t.plan(1)
 
-    let actual = bech32.decode(string)
+    let actual = bech32.decode(f.prefix, string)
     t.same(actual, {
-      prefix: f.prefix,
-      data: buffer
+      version: f.version,
+      program: buffer
     })
   })
 })


### PR DESCRIPTION
Updates test fixtures, separating address tests from bech32 tests.

Changes address decode to return witness program as a Buffer instead
of an integer array.

Fixes incorrect bitData length bound to include 65 as valid.

Fixes bech32.decode result data length, removing trailing zeros
previously occupied by the 6-character checksum

Solves failure in #2. Does nothing about separating addresses from this library.