### PR TITLE
Add tests for /bech32, 100% test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage/
 node_modules/
+.nyc_output

--- a/bech32.js
+++ b/bech32.js
@@ -35,16 +35,12 @@ function encode (prefix, words) {
   }
   chk = polymodStep(chk)
 
-  let result = ''
   for (let i = 0; i < prefix.length; ++i) {
-    let c = prefix.charAt(i)
     let v = prefix.charCodeAt(i)
     chk = polymodStep(chk) ^ (v & 0x1f)
-
-    result += c
   }
-  result += '1'
 
+  let result = prefix + '1'
   for (let i = 0; i < words.length; ++i) {
     let x = words[i]
     if ((x >> 5) !== 0) throw new Error('Non 5-bit word')
@@ -75,9 +71,10 @@ function decode (str) {
   if (str !== lowered) throw new Error('Non-lowercase string ' + str)
 
   let split = str.lastIndexOf('1')
+  if (split === 0) throw new Error('Missing prefix for ' + str)
+
   let prefix = str.slice(0, split)
   let wordChars = str.slice(split + 1)
-  if (prefix.length < 1) throw new Error('Missing prefix for ' + str)
   if (wordChars.length < 6) throw new Error('Data too short')
 
   // determine chk mod

--- a/bech32.js
+++ b/bech32.js
@@ -68,7 +68,9 @@ function decode (str) {
 
   // don't allow mixed case
   let lowered = str.toLowerCase()
-  if (str !== lowered) throw new Error('Non-lowercase string ' + str)
+  let uppered = str.toUpperCase()
+  if (str !== lowered && str !== uppered) throw new Error('Mixed-case string ' + str)
+  str = lowered
 
   let split = str.lastIndexOf('1')
   if (split === 0) throw new Error('Missing prefix for ' + str)

--- a/index.js
+++ b/index.js
@@ -1,59 +1,38 @@
 'use strict'
-let assert = require('assert')
 let bech32 = require('./bech32')
 
-function convertBits (data, inbits, outbits, pad) {
-  let val = 0
-  let bits = 0
-  let maxv = (1 << outbits) - 1
-  let ret = []
-
-  for (let i = 0; i < data.length; ++i) {
-    val = (val << inbits) | data[i]
-    bits += inbits
-
-    while (bits >= outbits) {
-      bits -= outbits
-      ret.push((val >> bits) & maxv)
-    }
-  }
-
-  if (pad) {
-    if (bits > 0) {
-      ret.push((val << (outbits - bits)) & maxv)
-    }
-  } else {
-    assert(bits < inbits)
-    assert(!((val << (outbits - bits)) & maxv))
-  }
-
-  return ret
-}
-
 function encode (prefix, version, program) {
-  // witness version 0 length checks
+  if (version > 16) throw new Error('Invalid version (' + version + ')')
   if (version === 0) {
-    assert((program.length === 20) || (program.length === 32))
+    if (program.length !== 20 && program.length !== 32) throw new Error('Unknown program')
+  } else {
+    if (program.length < 2) throw new Error('Program too short')
+    if (program.length > 40) throw new Error('Program too long')
   }
 
-  let bitData = convertBits(program, 8, 5, true)
-  bitData.unshift(version)
+  let words = bech32.toWords(program)
+  words.unshift(version)
 
-  return bech32.encode(prefix, bitData)
+  return bech32.encode(prefix, words)
 }
 
-function decode (expectedPrefix, string) {
+function decode (string, expectedPrefix) {
   let result = bech32.decode(string)
-  assert.equal(result.prefix, expectedPrefix)
+  let prefix = result.prefix
+  let words = result.words
+  if (expectedPrefix !== undefined) {
+    if (prefix !== expectedPrefix) throw new Error('Expected ' + expectedPrefix + ', got ' + prefix)
+  }
 
-  assert((result.bitData.length > 0) && (result.bitData.length < 66))
-  let version = result.bitData[0]
-  let program = convertBits(result.bitData.slice(1), 5, 8, false)
-  assert((program.length > 1) && (program.length < 41))
+  let version = words[0]
+  if (version > 16) throw new Error('Invalid version (' + version + ')')
+  let program = bech32.fromWords(words.slice(1))
 
-  // witness version 0 length checks
   if (version === 0) {
-    assert((program.length === 20) || (program.length === 32))
+    if (program.length !== 20 && program.length !== 32) throw new Error('Unknown program')
+  } else {
+    if (program.length < 2) throw new Error('Program too short')
+    if (program.length > 40) throw new Error('Program too long')
   }
 
   return { version, program: Buffer.from(program) }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "type": "git"
   },
   "scripts": {
-    "coverage": "nyc --check-coverage --branches 90 --functions 90 tape test/index.js",
+    "coverage": "nyc --check-coverage --branches 90 --functions 90 tape test/*.js",
     "standard": "standard",
-    "test": "tape test/index.js | tap-dot"
+    "test": "tape test/*.js | tap-dot"
   }
 }

--- a/test/bech32.js
+++ b/test/bech32.js
@@ -1,0 +1,71 @@
+'use strict'
+let tape = require('tape')
+let fixtures = require('./fixtures')
+let bech32 = require('../bech32')
+
+fixtures.bech32.valid.forEach((f) => {
+  tape(`fromWords/toWords ${f.hex}`, (t) => {
+    t.plan(2)
+
+    let words = bech32.toWords(Buffer.from(f.hex, 'hex'))
+    let bytes = Buffer.from(bech32.fromWords(f.words))
+    t.same(words, f.words)
+    t.same(bytes.toString('hex'), f.hex)
+  })
+
+  tape(`encode ${f.prefix} ${f.hex}`, (t) => {
+    t.plan(1)
+
+    t.strictEqual(bech32.encode(f.prefix, f.words), f.string)
+  })
+
+  tape(`decode ${f.string}`, (t) => {
+    t.plan(1)
+
+    t.same(bech32.decode(f.string), {
+      prefix: f.prefix,
+      words: f.words
+    })
+  })
+
+  tape(`fails for ${f.string} with 1 bit flipped`, (t) => {
+    t.plan(1)
+
+    let buffer = Buffer.from(f.string, 'utf8')
+    buffer[f.string.lastIndexOf('1') + 1] ^= 0x1 // flip a bit, after the prefix
+    let string = buffer.toString('utf8')
+    t.throws(function () {
+      bech32.decode(string)
+    }, new RegExp('Invalid checksum|Unknown character'))
+  })
+})
+
+fixtures.bech32.invalid.forEach((f) => {
+  if (f.prefix !== undefined && f.words !== undefined) {
+    tape(`encode fails with (${f.exception})`, (t) => {
+      t.plan(1)
+
+      t.throws(function () {
+        bech32.encode(f.prefix, f.words)
+      }, new RegExp(f.exception))
+    })
+  }
+
+  if (f.string !== undefined) {
+    tape(`decode fails for ${f.string} (${f.exception})`, (t) => {
+      t.plan(1)
+      t.throws(function () {
+        bech32.decode(f.string)
+      }, new RegExp(f.exception))
+    })
+  }
+})
+
+fixtures.fromWords.invalid.forEach((f) => {
+  tape(`fromWords fails with ${f.exception}`, (t) => {
+    t.plan(1)
+    t.throws(function () {
+      bech32.fromWords(f.words)
+    }, new RegExp(f.exception))
+  })
+})

--- a/test/bech32.js
+++ b/test/bech32.js
@@ -16,14 +16,14 @@ fixtures.bech32.valid.forEach((f) => {
   tape(`encode ${f.prefix} ${f.hex}`, (t) => {
     t.plan(1)
 
-    t.strictEqual(bech32.encode(f.prefix, f.words), f.string)
+    t.strictEqual(bech32.encode(f.prefix, f.words), f.string.toLowerCase())
   })
 
   tape(`decode ${f.string}`, (t) => {
     t.plan(1)
 
     t.same(bech32.decode(f.string), {
-      prefix: f.prefix,
+      prefix: f.prefix.toLowerCase(),
       words: f.words
     })
   })

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -39,46 +39,160 @@
       }
     ],
     "invalid": [
-      "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
-      "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-      "bc1rw5uspcuh",
-      "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
-      "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-      "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
-      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
+      {
+        "ignore": true,
+        "string": "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+        "exception": "Invalid network"
+      },
+      {
+        "string": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+        "exception": "Invalid checksum"
+      },
+      {
+        "string": "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+        "prefix": "bc",
+        "version": 17,
+        "program": "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "exception": "Invalid version \\(17\\)"
+      },
+      {
+        "string": "BC1SW50QA3JX3S",
+        "prefix": "foo",
+        "exception": "Expected foo, got bc"
+      },
+      {
+        "string": "bc1rw5uspcuh",
+        "prefix": "bc",
+        "version": 1,
+        "program": "75",
+        "exception": "Program too short"
+      },
+      {
+        "string": "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+        "prefix": "bc",
+        "version": 1,
+        "program": "751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd675",
+        "exception": "Program too long"
+      },
+      {
+        "string": "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+        "prefix": "bc",
+        "version": 0,
+        "program": "1d1e76e8199196d454941c45d1b3a323",
+        "exception": "Unknown program"
+      },
+      {
+        "string": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+        "exception": "Mixed-case string"
+      },
+      {
+        "string": "tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
+        "exception": "Excess padding"
+      },
+      {
+        "string": "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+        "exception": "Non-zero padding"
+      }
+    ]
+  },
+  "fromWords": {
+    "invalid": [
+      {
+        "exception": "Excess padding",
+        "words": [14,20,15,7,13,26,0,25,18,6,11,13,8,21,4,20,3,17,2,29,3,0]
+      },
+      {
+        "exception": "Non-zero padding",
+        "words": [3,1,17,17,8,15,0,20,24,20,11,6,16,1,5,29,3,4,16,3,6,21,22,26,2,13,22,9,16,21,19,24,25,21,6,18,15,8,13,24,24,24,25,9,12,1,4,16,6,9,17,1]
+      }
     ]
   },
   "bech32": {
     "valid": [
       {
-        "string": "A12UEL5L",
+        "string": "a12uel5l",
         "prefix": "a",
-        "hex": ""
+        "hex": "",
+        "words": []
       },
       {
         "string": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
         "prefix": "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
-        "hex": ""
+        "hex": "",
+        "words": []
       },
       {
         "string": "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
         "prefix": "abcdef",
-        "hex": "00443214c74254b635cf84653a56d7c675be77df"
+        "hex": "00443214c74254b635cf84653a56d7c675be77df",
+        "words": [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
       },
       {
         "string": "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
         "prefix": "1",
-        "hex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "hex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "words": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
       },
       {
         "string": "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
         "prefix": "split",
-        "hex": "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d"
+        "hex": "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d",
+        "words": [24,23,25,24,22,28,1,16,11,29,8,25,23,29,19,13,16,23,29,22,25,28,1,16,11,3,25,29,27,25,3,3,29,19,11,25,3,3,25,13,24,29,1,25,3,3,25,13]
       }
     ],
     "invalid": [
+      {
+        "string": "A12UEL5L",
+        "exception": "Non-lowercase string A12UEL5L"
+      },
+      {
+        "string": " 1nwldj5",
+        "exception": "Invalid prefix \\( \\)"
+      },
+      {
+        "string": "abc1rzg",
+        "exception": "abc1rzg too short"
+      },
+      {
+        "string": "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+        "exception": "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx too long"
+      },
+      {
+        "string": "x1b4n0q5v",
+        "exception": "Unknown character b"
+      },
+      {
+        "string": "1pzry9x0s0muk",
+        "exception": "Missing prefix for 1pzry9x0s0muk"
+      },
+      {
+        "string": "pzry9x0s0muk",
+        "exception": "Invalid checksum for pzry9x0s0muk"
+      },
+      {
+        "string": "abc1rzgt4",
+        "exception": "Data too short"
+      },
+      {
+        "prefix": "abc",
+        "words": [128],
+        "exception": "Non 5-bit word"
+      },
+      {
+        "prefix": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoobarfoobar",
+        "words": [128],
+        "exception": "Exceeds Bech32 maximum length"
+      },
+      {
+        "prefix": "foobar",
+        "words": [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+        "exception": "Exceeds Bech32 maximum length"
+      },
+      {
+        "prefix": "abc\u00ff",
+        "words": [18],
+        "exception": "Invalid prefix \\(abc\u00ff\\)"
+      }
     ]
   }
 }

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -110,8 +110,8 @@
   "bech32": {
     "valid": [
       {
-        "string": "a12uel5l",
-        "prefix": "a",
+        "string": "A12UEL5L",
+        "prefix": "A",
         "hex": "",
         "words": []
       },
@@ -142,8 +142,8 @@
     ],
     "invalid": [
       {
-        "string": "A12UEL5L",
-        "exception": "Non-lowercase string A12UEL5L"
+        "string": "A12Uel5l",
+        "exception": "Mixed-case string A12Uel5l"
       },
       {
         "string": " 1nwldj5",

--- a/test/index.js
+++ b/test/index.js
@@ -16,10 +16,30 @@ fixtures.addresses.valid.forEach((f, i) => {
   tape('decode ' + string, (t) => {
     t.plan(1)
 
-    let actual = bech32.decode(f.prefix, string)
-    t.same(actual, {
+    t.same(bech32.decode(string, f.prefix), {
       version: f.version,
       program: buffer
     })
   })
+})
+
+fixtures.addresses.invalid.forEach((f, i) => {
+  if (f.ignore) return
+  if (f.prefix && f.version !== undefined && f.program !== undefined) {
+    tape(`encode fails (${f.exception})`, (t) => {
+      t.plan(1)
+      t.throws(function () {
+        bech32.encode(f.prefix, f.version, Buffer.from(f.program, 'hex'))
+      }, new RegExp(f.exception))
+    })
+  }
+
+  if (f.string !== undefined) {
+    tape(`decode fails for ${f.string} (${f.exception})`, (t) => {
+      t.plan(1)
+      t.throws(function () {
+        bech32.decode(f.string, f.prefix)
+      }, new RegExp(f.exception))
+    })
+  }
 })


### PR DESCRIPTION
~~Pre-cursor to https://github.com/bitcoinjs/bech32/pull/8/files?~~
~~Just getting the test fixtures in so I can understand why https://github.com/bitcoinjs/bech32/issues/7 was an issue.~~

Alternative to #8 (albeit missing the removal of the SegWit address exports)