### PR TITLE
Add type declaration file for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export function decode(str: string, limit?: number): { prefix: string, words: nu
  * Takes a human readable part ("prefix") and a list of character positions in the
  * bech32 alphabet ("words") and returns a bech32 encoded string.
  */
-export function encode(prefix: string, words: Buffer, limit?: number): string;
+export function encode(prefix: string, words: number[], limit?: number): string;
 
 /**
  * Converts a list of character positions in the bech32 alphabet ("words")

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 /**
  * Takes a bech32 encoded string and returns the human readable part ("prefix") and
  * a list of character positions in the bech32 alphabet ("words").
+ *
+ * @throws Throws on error
  */
 export function decode(str: string, limit?: number): { prefix: string, words: number[] };
 
@@ -20,6 +22,8 @@ export function encode(prefix: string, words: number[], limit?: number): string;
  * const a = new Uint8Array(fromWords(words));
  * const b = Buffer.from(fromWords(words));
  * ```
+ *
+ * @throws Throws on error
  */
 export function fromWords(words: number[]): number[];
 
@@ -32,5 +36,7 @@ export function fromWords(words: number[]): number[];
  * const a = toWords(new Uint8Array([0x00, 0x11, 0x22]));
  * const b = toWords(Buffer.from("001122", "hex"));
  * ```
+ *
+ * @throws Throws on error
  */
 export function toWords(bytes: ArrayLike<number>): number[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Takes a bech32 encoded string and returns the human readable part ("prefix") and
+ * a list of character positions in the bech32 alphabet ("words").
+ */
+export function decode(str: string, limit?: number): { prefix: string, words: number[] };
+
+/**
+ * Takes a human readable part ("prefix") and a list of character positions in the
+ * bech32 alphabet ("words") and returns a bech32 encoded string.
+ */
+export function encode(prefix: string, words: Buffer, limit?: number): string;
+
+/**
+ * Converts a list of character positions in the bech32 alphabet ("words")
+ * to binary data.
+ *
+ * The returned data can be used to construct an Uint8Array or Buffer like this:
+ *
+ * ```ts
+ * const a = new Uint8Array(fromWords(words));
+ * const b = Buffer.from(fromWords(words));
+ * ```
+ */
+export function fromWords(words: number[]): number[];
+
+/**
+ * Converts binary data to a list of character positions in the bech32 alphabet ("words").
+ *
+ * Uint8Arrays and Buffers can be passed as an argument directly:
+ *
+ * ```ts
+ * const a = toWords(new Uint8Array([0x00, 0x11, 0x22]));
+ * const b = toWords(Buffer.from("001122", "hex"));
+ * ```
+ */
+export function toWords(bytes: ArrayLike<number>): number[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,14 @@
 export function decode(str: string, limit?: number): { prefix: string, words: number[] };
 
 /**
+ * Takes a bech32 encoded string and returns the human readable part ("prefix") and
+ * a list of character positions in the bech32 alphabet ("words").
+ *
+ * @returns undefined when there was an error
+ */
+export function decodeUnsafe(str: string, limit?: number): ({ prefix: string, words: number[] }) | undefined;
+
+/**
  * Takes a human readable part ("prefix") and a list of character positions in the
  * bech32 alphabet ("words") and returns a bech32 encoded string.
  */
@@ -28,6 +36,21 @@ export function encode(prefix: string, words: number[], limit?: number): string;
 export function fromWords(words: number[]): number[];
 
 /**
+ * Converts a list of character positions in the bech32 alphabet ("words")
+ * to binary data.
+ *
+ * The returned data can be used to construct an Uint8Array or Buffer like this:
+ *
+ * ```ts
+ * const a = new Uint8Array(fromWordsUnsafe(words));
+ * const b = Buffer.from(fromWordsUnsafe(words));
+ * ```
+ *
+ * @returns undefined when there was an error
+ */
+export function fromWordsUnsafe(words: number[]): number[] | undefined;
+
+/**
  * Converts binary data to a list of character positions in the bech32 alphabet ("words").
  *
  * Uint8Arrays and Buffers can be passed as an argument directly:
@@ -40,3 +63,17 @@ export function fromWords(words: number[]): number[];
  * @throws Throws on error
  */
 export function toWords(bytes: ArrayLike<number>): number[];
+
+/**
+ * Converts binary data to a list of character positions in the bech32 alphabet ("words").
+ *
+ * Uint8Arrays and Buffers can be passed as an argument directly:
+ *
+ * ```ts
+ * const a = toWordsUnsafe(new Uint8Array([0x00, 0x11, 0x22]));
+ * const b = toWordsUnsafe(Buffer.from("001122", "hex"));
+ * ```
+ *
+ * @returns undefined when there was an error
+ */
+export function toWordsUnsafe(bytes: ArrayLike<number>): number[] | undefined;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "encoding"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "index.js"
   ],

--- a/test/index.js
+++ b/test/index.js
@@ -75,3 +75,27 @@ fixtures.fromWords.invalid.forEach((f) => {
     }, new RegExp(f.exception))
   })
 })
+
+tape(`toWords/toWordsUnsafe accept bytes as ArrayLike<number>`, (t) => {
+  // Ensures that only the two operations from
+  //   interface ArrayLike<T> {
+  //     readonly length: number;
+  //     readonly [n: number]: T;
+  //   }
+  // are used, which are common for the typical binary types Uint8Array, Buffer and
+  // Array<number>.
+
+  const bytes = {
+    length: 5,
+    0: 0x00,
+    1: 0x11,
+    2: 0x22,
+    3: 0x33,
+    4: 0xff
+  }
+  const words1 = bech32.toWords(bytes)
+  const words2 = bech32.toWordsUnsafe(bytes)
+  t.plan(2)
+  t.same(words1, [0, 0, 8, 18, 4, 12, 31, 31])
+  t.same(words2, [0, 0, 8, 18, 4, 12, 31, 31])
+})

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,50 @@
+// This is a simple example file that shows the usage of this library in TypeScript.
+// When you open it in Visual Studio Code, the built-in TypeScript server should run all
+// the type checks. For manually runtime testing you can use ts-node to run this file.
+
+import * as bech32 from "..";
+
+function encodeUint8Array(prefix: string, data: Uint8Array): string {
+  const address = bech32.encode(prefix, bech32.toWords(data));
+  return address;
+}
+
+function decodeUint8Array(address: string): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decode(address);
+  return {
+    prefix: decodedAddress.prefix,
+    data: new Uint8Array(bech32.fromWords(decodedAddress.words)),
+  };
+}
+
+function encodeBuffer(prefix: string, data: Buffer): string {
+  const address = bech32.encode(prefix, bech32.toWords(data));
+  return address;
+}
+
+function decodeBuffer(address: string): { readonly prefix: string; readonly data: Buffer } {
+  const decodedAddress = bech32.decode(address);
+  return {
+    prefix: decodedAddress.prefix,
+    data: Buffer.from(bech32.fromWords(decodedAddress.words)),
+  };
+}
+
+function main(): void {
+  {
+    const prefix = "foo";
+    const data = new Uint8Array([0x00, 0x11, 0x22]);
+    const address = encodeUint8Array(prefix, data);
+    const decoded = decodeUint8Array(address);
+    console.log(prefix, data, address, decoded);
+  }
+  {
+    const prefix = "foo";
+    const data = Buffer.from([0x00, 0x11, 0x22]);
+    const address = encodeBuffer(prefix, data);
+    const decoded = decodeBuffer(address);
+    console.log(prefix, data, address, decoded);
+  }
+}
+
+main();

--- a/test/types.ts
+++ b/test/types.ts
@@ -30,6 +30,19 @@ function decodeBuffer(address: string): { readonly prefix: string; readonly data
   };
 }
 
+function encodeUnsafe(prefix: string, data: Uint8Array): string | undefined {
+  const address = bech32.encode(prefix, bech32.toWordsUnsafe(data));
+  return address;
+}
+
+function decodeUnsafe(address: string): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decodeUnsafe(address);
+  return {
+    prefix: decodedAddress.prefix,
+    data: new Uint8Array(bech32.fromWordsUnsafe(decodedAddress.words)),
+  };
+}
+
 function main(): void {
   {
     const prefix = "foo";
@@ -43,6 +56,13 @@ function main(): void {
     const data = Buffer.from([0x00, 0x11, 0x22]);
     const address = encodeBuffer(prefix, data);
     const decoded = decodeBuffer(address);
+    console.log(prefix, data, address, decoded);
+  }
+  {
+    const prefix = "foo";
+    const data = new Uint8Array([0x00, 0x11, 0x22]);
+    const address = encodeUnsafe(prefix, data);
+    const decoded = decodeUnsafe(address);
     console.log(prefix, data, address, decoded);
   }
 }


### PR DESCRIPTION
I would like to contribute those types here because
* [@types/bech32](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/bech32/index.d.ts) is wrong on many places (Buffer is used when there is an array of number at runtime)
* It is easier to keep types and runtime code in sync when they are both in the same repo and npm package
* In our use case we use Uint8Array instead of Buffer for all binary data and those types allow users to works with both of them

Those type declarations are used in production-ready software (see https://github.com/iov-one/iov-core/pull/1165)