### PR TITLE
Add BIP350 Bech32m support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,29 @@
 [![build status](https://secure.travis-ci.org/bitcoinjs/bech32.png)](http://travis-ci.org/bitcoinjs/bech32)
 [![Version](http://img.shields.io/npm/v/bech32.svg)](https://www.npmjs.org/package/bech32)
 
-A [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) compatible Bech32 encoding/decoding library.
+A [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)/[BIP350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) compatible Bech32/Bech32m encoding/decoding library.
 
 
 ## Example
 ``` javascript
 let bech32 = require('bech32')
 
-bech32.decode('abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw')
+bech32.decode('abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw', bech32.encodings.BECH32)
 // => {
 // 	 prefix: 'abcdef',
 // 	 words: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
 // }
+bech32.decode('abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx', bech32.encodings.BECH32M)
+// => {
+// 	 prefix: 'abcdef',
+// 	 words: [31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+// }
 
 let words = bech32.toWords(Buffer.from('foobar', 'utf8'))
-bech32.encode('foo', words)
+bech32.encode('foo', words, bech32.encodings.BECH32)
 // => 'foo1vehk7cnpwgry9h96'
+bech32.encode('foo', words, bech32.encodings.BECH32M)
+// => 'foo1vehk7cnpwgkc4mqc'
 ```
 
 
@@ -28,7 +35,7 @@ It is highly recommended **NOT** exceed 1023 characters, as the module could onl
 
 
 ## Credits
-- [Peter Wuille](https://github.com/sipa/bech32) for the reference JavaScript implementation, and for authoring the Bech32 [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki).
+- [Peter Wuille](https://github.com/sipa/bech32) for the reference JavaScript implementation, and for authoring the Bech32 [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) and Bech32m [BIP350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
 
 
 ## License [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -7,23 +7,24 @@ A [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)/[BIP3
 
 ## Example
 ``` javascript
-let bech32 = require('bech32')
+let { bech32, bech32m } = require('bech32')
 
-bech32.decode('abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw', bech32.encodings.BECH32)
+bech32.decode('abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw')
 // => {
 // 	 prefix: 'abcdef',
 // 	 words: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
 // }
-bech32.decode('abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx', bech32.encodings.BECH32M)
+bech32m.decode('abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx')
 // => {
 // 	 prefix: 'abcdef',
 // 	 words: [31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
 // }
 
+// toWords etc. are available on both bech32 and bech32m objects
 let words = bech32.toWords(Buffer.from('foobar', 'utf8'))
-bech32.encode('foo', words, bech32.encodings.BECH32)
+bech32.encode('foo', words)
 // => 'foo1vehk7cnpwgry9h96'
-bech32.encode('foo', words, bech32.encodings.BECH32M)
+bech32m.encode('foo', words)
 // => 'foo1vehk7cnpwgkc4mqc'
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,18 @@
 /**
+ * The encoding type to encode/decode
+ */
+export const enum Encoding {
+  BECH32 = 'bech32',
+  BECH32M = 'bech32m'
+}
+
+/**
  * Takes a bech32 encoded string and returns the human readable part ("prefix") and
  * a list of character positions in the bech32 alphabet ("words").
  *
  * @throws Throws on error
  */
-export function decode(str: string, limit?: number): { prefix: string, words: number[] };
+export function decode(str: string, encoding: Encoding, limit?: number): { prefix: string, words: number[] };
 
 /**
  * Takes a bech32 encoded string and returns the human readable part ("prefix") and
@@ -12,13 +20,13 @@ export function decode(str: string, limit?: number): { prefix: string, words: nu
  *
  * @returns undefined when there was an error
  */
-export function decodeUnsafe(str: string, limit?: number): ({ prefix: string, words: number[] }) | undefined;
+export function decodeUnsafe(str: string, encoding: Encoding, limit?: number): ({ prefix: string, words: number[] }) | undefined;
 
 /**
- * Takes a human readable part ("prefix") and a list of character positions in the
- * bech32 alphabet ("words") and returns a bech32 encoded string.
+ * Takes a human readable part ("prefix"), a list of character positions in the
+ * bech32 alphabet ("words") and the encoding type, and returns a bech32 encoded string.
  */
-export function encode(prefix: string, words: number[], limit?: number): string;
+export function encode(prefix: string, words: number[], encoding: Encoding, limit?: number): string;
 
 /**
  * Converts a list of character positions in the bech32 alphabet ("words")

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,87 +1,84 @@
-/**
- * The encoding type to encode/decode
- */
-export const enum Encoding {
-  BECH32 = 'bech32',
-  BECH32M = 'bech32m'
+interface ConverterLib {
+  /**
+   * Takes a bech32 encoded string and returns the human readable part ("prefix") and
+   * a list of character positions in the bech32 alphabet ("words").
+   *
+   * @throws Throws on error
+   */
+  decode(str: string, limit?: number): { prefix: string, words: number[] };
+
+  /**
+   * Takes a bech32 encoded string and returns the human readable part ("prefix") and
+   * a list of character positions in the bech32 alphabet ("words").
+   *
+   * @returns undefined when there was an error
+   */
+  decodeUnsafe(str: string, limit?: number): ({ prefix: string, words: number[] }) | undefined;
+
+  /**
+   * Takes a human readable part ("prefix") and a list of character positions in the
+   * bech32 alphabet ("words"), and returns a bech32 encoded string.
+   */
+  encode(prefix: string, words: number[], limit?: number): string;
+
+  /**
+   * Converts a list of character positions in the bech32 alphabet ("words")
+   * to binary data.
+   *
+   * The returned data can be used to construct an Uint8Array or Buffer like this:
+   *
+   * ```ts
+   * const a = new Uint8Array(fromWords(words));
+   * const b = Buffer.from(fromWords(words));
+   * ```
+   *
+   * @throws Throws on error
+   */
+  fromWords(words: number[]): number[];
+
+  /**
+   * Converts a list of character positions in the bech32 alphabet ("words")
+   * to binary data.
+   *
+   * The returned data can be used to construct an Uint8Array or Buffer like this:
+   *
+   * ```ts
+   * const a = new Uint8Array(fromWordsUnsafe(words));
+   * const b = Buffer.from(fromWordsUnsafe(words));
+   * ```
+   *
+   * @returns undefined when there was an error
+   */
+  fromWordsUnsafe(words: number[]): number[] | undefined;
+
+  /**
+   * Converts binary data to a list of character positions in the bech32 alphabet ("words").
+   *
+   * Uint8Arrays and Buffers can be passed as an argument directly:
+   *
+   * ```ts
+   * const a = toWords(new Uint8Array([0x00, 0x11, 0x22]));
+   * const b = toWords(Buffer.from("001122", "hex"));
+   * ```
+   *
+   * @throws Throws on error
+   */
+  toWords(bytes: ArrayLike<number>): number[];
+
+  /**
+   * Converts binary data to a list of character positions in the bech32 alphabet ("words").
+   *
+   * Uint8Arrays and Buffers can be passed as an argument directly:
+   *
+   * ```ts
+   * const a = toWordsUnsafe(new Uint8Array([0x00, 0x11, 0x22]));
+   * const b = toWordsUnsafe(Buffer.from("001122", "hex"));
+   * ```
+   *
+   * @returns undefined when there was an error
+   */
+  toWordsUnsafe(bytes: ArrayLike<number>): number[] | undefined;
 }
 
-/**
- * Takes a bech32 encoded string and returns the human readable part ("prefix") and
- * a list of character positions in the bech32 alphabet ("words").
- *
- * @throws Throws on error
- */
-export function decode(str: string, encoding: Encoding, limit?: number): { prefix: string, words: number[] };
-
-/**
- * Takes a bech32 encoded string and returns the human readable part ("prefix") and
- * a list of character positions in the bech32 alphabet ("words").
- *
- * @returns undefined when there was an error
- */
-export function decodeUnsafe(str: string, encoding: Encoding, limit?: number): ({ prefix: string, words: number[] }) | undefined;
-
-/**
- * Takes a human readable part ("prefix"), a list of character positions in the
- * bech32 alphabet ("words") and the encoding type, and returns a bech32 encoded string.
- */
-export function encode(prefix: string, words: number[], encoding: Encoding, limit?: number): string;
-
-/**
- * Converts a list of character positions in the bech32 alphabet ("words")
- * to binary data.
- *
- * The returned data can be used to construct an Uint8Array or Buffer like this:
- *
- * ```ts
- * const a = new Uint8Array(fromWords(words));
- * const b = Buffer.from(fromWords(words));
- * ```
- *
- * @throws Throws on error
- */
-export function fromWords(words: number[]): number[];
-
-/**
- * Converts a list of character positions in the bech32 alphabet ("words")
- * to binary data.
- *
- * The returned data can be used to construct an Uint8Array or Buffer like this:
- *
- * ```ts
- * const a = new Uint8Array(fromWordsUnsafe(words));
- * const b = Buffer.from(fromWordsUnsafe(words));
- * ```
- *
- * @returns undefined when there was an error
- */
-export function fromWordsUnsafe(words: number[]): number[] | undefined;
-
-/**
- * Converts binary data to a list of character positions in the bech32 alphabet ("words").
- *
- * Uint8Arrays and Buffers can be passed as an argument directly:
- *
- * ```ts
- * const a = toWords(new Uint8Array([0x00, 0x11, 0x22]));
- * const b = toWords(Buffer.from("001122", "hex"));
- * ```
- *
- * @throws Throws on error
- */
-export function toWords(bytes: ArrayLike<number>): number[];
-
-/**
- * Converts binary data to a list of character positions in the bech32 alphabet ("words").
- *
- * Uint8Arrays and Buffers can be passed as an argument directly:
- *
- * ```ts
- * const a = toWordsUnsafe(new Uint8Array([0x00, 0x11, 0x22]));
- * const b = toWordsUnsafe(Buffer.from("001122", "hex"));
- * ```
- *
- * @returns undefined when there was an error
- */
-export function toWordsUnsafe(bytes: ArrayLike<number>): number[] | undefined;
+export const bech32: ConverterLib;
+export const bech32m: ConverterLib;

--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ function prefixChk (prefix) {
 
 function encode (prefix, words, encoding, LIMIT) {
   LIMIT = LIMIT || 90
+  const encodingConst = getEncodingConst(encoding)
+  if (encodingConst === null) throw new TypeError('Encoding must be either bech32 or bech32m')
   if ((prefix.length + 7 + words.length) > LIMIT) throw new TypeError('Exceeds length limit')
 
   prefix = prefix.toLowerCase()
@@ -74,7 +76,7 @@ function encode (prefix, words, encoding, LIMIT) {
   for (i = 0; i < 6; ++i) {
     chk = polymodStep(chk)
   }
-  chk ^= getEncodingConst(encoding)
+  chk ^= encodingConst
 
   for (i = 0; i < 6; ++i) {
     var v = (chk >> ((5 - i) * 5)) & 0x1f
@@ -88,6 +90,9 @@ function __decode (str, encoding, LIMIT) {
   LIMIT = LIMIT || 90
   if (str.length < 8) return str + ' too short'
   if (str.length > LIMIT) return 'Exceeds length limit'
+
+  const encodingConst = getEncodingConst(encoding)
+  if (encodingConst === null) throw new TypeError('Encoding must be either bech32 or bech32m')
 
   // don't allow mixed case
   var lowered = str.toLowerCase()
@@ -118,7 +123,7 @@ function __decode (str, encoding, LIMIT) {
     words.push(v)
   }
 
-  if (chk !== getEncodingConst(encoding)) return 'Invalid checksum for ' + str
+  if (chk !== encodingConst) return 'Invalid checksum for ' + str
   return { prefix: prefix, words: words }
 }
 

--- a/index.js
+++ b/index.js
@@ -6,23 +6,9 @@ var ALPHABET_MAP = {}
 for (var z = 0; z < ALPHABET.length; z++) {
   var x = ALPHABET.charAt(z)
 
+  /* istanbul ignore if */
   if (ALPHABET_MAP[x] !== undefined) throw new TypeError(x + ' is ambiguous')
   ALPHABET_MAP[x] = z
-}
-
-var encodings = {
-  BECH32: 'bech32',
-  BECH32M: 'bech32m'
-}
-
-function getEncodingConst (encoding) {
-  if (encoding === encodings.BECH32) {
-    return 1
-  } else if (encoding === encodings.BECH32M) {
-    return 0x2bc830a3
-  } else {
-    return null
-  }
 }
 
 function polymodStep (pre) {
@@ -50,93 +36,6 @@ function prefixChk (prefix) {
     chk = polymodStep(chk) ^ (v & 0x1f)
   }
   return chk
-}
-
-function encode (prefix, words, encoding, LIMIT) {
-  LIMIT = LIMIT || 90
-  const encodingConst = getEncodingConst(encoding)
-  if (encodingConst === null) throw new TypeError('Encoding must be either bech32 or bech32m')
-  if ((prefix.length + 7 + words.length) > LIMIT) throw new TypeError('Exceeds length limit')
-
-  prefix = prefix.toLowerCase()
-
-  // determine chk mod
-  var chk = prefixChk(prefix)
-  if (typeof chk === 'string') throw new Error(chk)
-
-  var result = prefix + '1'
-  for (var i = 0; i < words.length; ++i) {
-    var x = words[i]
-    if ((x >> 5) !== 0) throw new Error('Non 5-bit word')
-
-    chk = polymodStep(chk) ^ x
-    result += ALPHABET.charAt(x)
-  }
-
-  for (i = 0; i < 6; ++i) {
-    chk = polymodStep(chk)
-  }
-  chk ^= encodingConst
-
-  for (i = 0; i < 6; ++i) {
-    var v = (chk >> ((5 - i) * 5)) & 0x1f
-    result += ALPHABET.charAt(v)
-  }
-
-  return result
-}
-
-function __decode (str, encoding, LIMIT) {
-  LIMIT = LIMIT || 90
-  if (str.length < 8) return str + ' too short'
-  if (str.length > LIMIT) return 'Exceeds length limit'
-
-  const encodingConst = getEncodingConst(encoding)
-  if (encodingConst === null) throw new TypeError('Encoding must be either bech32 or bech32m')
-
-  // don't allow mixed case
-  var lowered = str.toLowerCase()
-  var uppered = str.toUpperCase()
-  if (str !== lowered && str !== uppered) return 'Mixed-case string ' + str
-  str = lowered
-
-  var split = str.lastIndexOf('1')
-  if (split === -1) return 'No separator character for ' + str
-  if (split === 0) return 'Missing prefix for ' + str
-
-  var prefix = str.slice(0, split)
-  var wordChars = str.slice(split + 1)
-  if (wordChars.length < 6) return 'Data too short'
-
-  var chk = prefixChk(prefix)
-  if (typeof chk === 'string') return chk
-
-  var words = []
-  for (var i = 0; i < wordChars.length; ++i) {
-    var c = wordChars.charAt(i)
-    var v = ALPHABET_MAP[c]
-    if (v === undefined) return 'Unknown character ' + c
-    chk = polymodStep(chk) ^ v
-
-    // not in the checksum?
-    if (i + 6 >= wordChars.length) continue
-    words.push(v)
-  }
-
-  if (chk !== encodingConst) return 'Invalid checksum for ' + str
-  return { prefix: prefix, words: words }
-}
-
-function decodeUnsafe () {
-  var res = __decode.apply(null, arguments)
-  if (typeof res === 'object') return res
-}
-
-function decode (str) {
-  var res = __decode.apply(null, arguments)
-  if (typeof res === 'object') return res
-
-  throw new Error(res)
 }
 
 function convert (data, inBits, outBits, pad) {
@@ -169,13 +68,17 @@ function convert (data, inBits, outBits, pad) {
 
 function toWordsUnsafe (bytes) {
   var res = convert(bytes, 8, 5, true)
+  /* istanbul ignore else */
   if (Array.isArray(res)) return res
 }
 
 function toWords (bytes) {
   var res = convert(bytes, 8, 5, true)
+  /* istanbul ignore else */
   if (Array.isArray(res)) return res
 
+  // This is impossible to reach currently
+  /* istanbul ignore next */
   throw new Error(res)
 }
 
@@ -191,13 +94,113 @@ function fromWords (words) {
   throw new Error(res)
 }
 
+function getLibraryFromEncoding (encoding) {
+  var ENCODING_CONST
+  /* istanbul ignore else */
+  if (encoding === 'bech32') {
+    ENCODING_CONST = 1
+  } else if (encoding === 'bech32m') {
+    ENCODING_CONST = 0x2bc830a3
+  } else {
+    // This is just to protect us from ourselves
+    /* istanbul ignore next */
+    throw new Error('Invalid encoding')
+  }
+
+  function encode (prefix, words, LIMIT) {
+    LIMIT = LIMIT || 90
+    if ((prefix.length + 7 + words.length) > LIMIT) throw new TypeError('Exceeds length limit')
+
+    prefix = prefix.toLowerCase()
+
+    // determine chk mod
+    var chk = prefixChk(prefix)
+    if (typeof chk === 'string') throw new Error(chk)
+
+    var result = prefix + '1'
+    for (var i = 0; i < words.length; ++i) {
+      var x = words[i]
+      if ((x >> 5) !== 0) throw new Error('Non 5-bit word')
+
+      chk = polymodStep(chk) ^ x
+      result += ALPHABET.charAt(x)
+    }
+
+    for (i = 0; i < 6; ++i) {
+      chk = polymodStep(chk)
+    }
+    chk ^= ENCODING_CONST
+
+    for (i = 0; i < 6; ++i) {
+      var v = (chk >> ((5 - i) * 5)) & 0x1f
+      result += ALPHABET.charAt(v)
+    }
+
+    return result
+  }
+
+  function __decode (str, LIMIT) {
+    LIMIT = LIMIT || 90
+    if (str.length < 8) return str + ' too short'
+    if (str.length > LIMIT) return 'Exceeds length limit'
+
+    // don't allow mixed case
+    var lowered = str.toLowerCase()
+    var uppered = str.toUpperCase()
+    if (str !== lowered && str !== uppered) return 'Mixed-case string ' + str
+    str = lowered
+
+    var split = str.lastIndexOf('1')
+    if (split === -1) return 'No separator character for ' + str
+    if (split === 0) return 'Missing prefix for ' + str
+
+    var prefix = str.slice(0, split)
+    var wordChars = str.slice(split + 1)
+    if (wordChars.length < 6) return 'Data too short'
+
+    var chk = prefixChk(prefix)
+    if (typeof chk === 'string') return chk
+
+    var words = []
+    for (var i = 0; i < wordChars.length; ++i) {
+      var c = wordChars.charAt(i)
+      var v = ALPHABET_MAP[c]
+      if (v === undefined) return 'Unknown character ' + c
+      chk = polymodStep(chk) ^ v
+
+      // not in the checksum?
+      if (i + 6 >= wordChars.length) continue
+      words.push(v)
+    }
+
+    if (chk !== ENCODING_CONST) return 'Invalid checksum for ' + str
+    return { prefix: prefix, words: words }
+  }
+
+  function decodeUnsafe () {
+    var res = __decode.apply(null, arguments)
+    if (typeof res === 'object') return res
+  }
+
+  function decode (str) {
+    var res = __decode.apply(null, arguments)
+    if (typeof res === 'object') return res
+
+    throw new Error(res)
+  }
+
+  return {
+    decodeUnsafe: decodeUnsafe,
+    decode: decode,
+    encode: encode,
+    toWordsUnsafe: toWordsUnsafe,
+    toWords: toWords,
+    fromWordsUnsafe: fromWordsUnsafe,
+    fromWords: fromWords
+  }
+}
+
 module.exports = {
-  decodeUnsafe: decodeUnsafe,
-  decode: decode,
-  encode: encode,
-  toWordsUnsafe: toWordsUnsafe,
-  toWords: toWords,
-  fromWordsUnsafe: fromWordsUnsafe,
-  fromWords: fromWords,
-  encodings: encodings
+  bech32: getLibraryFromEncoding('bech32'),
+  bech32m: getLibraryFromEncoding('bech32m')
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,21 @@ for (var z = 0; z < ALPHABET.length; z++) {
   ALPHABET_MAP[x] = z
 }
 
+var encodings = {
+  BECH32: 'bech32',
+  BECH32M: 'bech32m'
+}
+
+function getEncodingConst (encoding) {
+  if (encoding === encodings.BECH32) {
+    return 1
+  } else if (encoding === encodings.BECH32M) {
+    return 0x2bc830a3
+  } else {
+    return null
+  }
+}
+
 function polymodStep (pre) {
   var b = pre >> 25
   return ((pre & 0x1FFFFFF) << 5) ^
@@ -37,7 +52,7 @@ function prefixChk (prefix) {
   return chk
 }
 
-function encode (prefix, words, LIMIT) {
+function encode (prefix, words, encoding, LIMIT) {
   LIMIT = LIMIT || 90
   if ((prefix.length + 7 + words.length) > LIMIT) throw new TypeError('Exceeds length limit')
 
@@ -59,7 +74,7 @@ function encode (prefix, words, LIMIT) {
   for (i = 0; i < 6; ++i) {
     chk = polymodStep(chk)
   }
-  chk ^= 1
+  chk ^= getEncodingConst(encoding)
 
   for (i = 0; i < 6; ++i) {
     var v = (chk >> ((5 - i) * 5)) & 0x1f
@@ -69,7 +84,7 @@ function encode (prefix, words, LIMIT) {
   return result
 }
 
-function __decode (str, LIMIT) {
+function __decode (str, encoding, LIMIT) {
   LIMIT = LIMIT || 90
   if (str.length < 8) return str + ' too short'
   if (str.length > LIMIT) return 'Exceeds length limit'
@@ -103,7 +118,7 @@ function __decode (str, LIMIT) {
     words.push(v)
   }
 
-  if (chk !== 1) return 'Invalid checksum for ' + str
+  if (chk !== getEncodingConst(encoding)) return 'Invalid checksum for ' + str
   return { prefix: prefix, words: words }
 }
 
@@ -178,5 +193,6 @@ module.exports = {
   toWordsUnsafe: toWordsUnsafe,
   toWords: toWords,
   fromWordsUnsafe: fromWordsUnsafe,
-  fromWords: fromWords
+  fromWords: fromWords,
+  encodings: encodings
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "keywords": [
     "base32",
     "bech32",
+    "bech32m",
     "bitcoin",
     "crypto",
     "crytography",

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -81,10 +81,6 @@
         "exception": "No separator character for pzry9x0s0muk"
       },
       {
-        "string": "1pzry9x0s0muk",
-        "exception": "Missing prefix for 1pzry9x0s0muk"
-      },
-      {
         "string": "abc1rzgt4",
         "exception": "Data too short"
       },
@@ -124,6 +120,154 @@
       },
       {
         "string": "li1dgmt3",
+        "exception": "Data too short"
+      },
+      {
+        "stringHex": "6465316c67377774ff",
+        "exception": "Unknown character "
+      }
+    ]
+  },
+  "bech32m": {
+    "valid": [
+      {
+        "string": "A1LQFN3A",
+        "prefix": "A",
+        "hex": "",
+        "words": []
+      },
+      {
+        "string": "a1lqfn3a",
+        "prefix": "a",
+        "hex": "",
+        "words": []
+      },
+      {
+        "string": "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+        "prefix": "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber1",
+        "hex": "",
+        "words": []
+      },
+      {
+        "string": "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+        "prefix": "abcdef",
+        "hex": "ffbbcdeb38bdab49ca307b9ac5a928398a418820",
+        "words": [31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]
+      },
+      {
+        "string": "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+        "prefix": "1",
+        "words": [31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31,31]
+      },
+      {
+        "string": "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+        "prefix": "split",
+        "hex": "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d",
+        "words": [24,23,25,24,22,28,1,16,11,29,8,25,23,29,19,13,16,23,29,22,25,28,1,16,11,3,25,29,27,25,3,3,29,19,11,25,3,3,25,13,24,29,1,25,3,3,25,13]
+      },
+      {
+        "string": "?1v759aa",
+        "prefix": "?",
+        "hex": "",
+        "words": []
+      },
+      {
+        "string": "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqszh4cp",
+        "prefix": "1",
+        "hex": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "words": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+        "limit": 300
+      }
+    ],
+    "invalid": [
+      {
+        "string": "A1LQfN3A",
+        "exception": "Mixed-case string A1LQfN3A"
+      },
+      {
+        "string": " 1xj0phk",
+        "exception": "Invalid prefix \\( \\)"
+      },
+      {
+        "string": "abc1rzg",
+        "exception": "abc1rzg too short"
+      },
+      {
+        "string": "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+        "exception": "Exceeds length limit"
+      },
+      {
+        "string": "qyrz8wqd2c9m",
+        "exception": "No separator character for qyrz8wqd2c9m"
+      },
+      {
+        "string": "1qyrz8wqd2c9m",
+        "exception": "Missing prefix for 1qyrz8wqd2c9m"
+      },
+      {
+        "string": "y1b0jsk6g",
+        "exception": "Unknown character b"
+      },
+      {
+        "string": "lt1igcx5c0",
+        "exception": "Unknown character i"
+      },
+      {
+        "string": "in1muywd",
+        "exception": "Data too short"
+      },
+      {
+        "string": "mm1crxm3i",
+        "exception": "Unknown character i"
+      },
+      {
+        "string": "au1s5cgom",
+        "exception": "Unknown character o"
+      },
+      {
+        "string": "M1VUXWEZ",
+        "exception": "Invalid checksum for m1vuxwez"
+      },
+      {
+        "string": "16plkw9",
+        "exception": "16plkw9 too short"
+      },
+      {
+        "string": "1p2gdwpf",
+        "exception": "Missing prefix for 1p2gdwpf"
+      },
+      {
+        "prefix": "abc",
+        "words": [128],
+        "exception": "Non 5-bit word"
+      },
+      {
+        "prefix": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoobarfoobar",
+        "words": [128],
+        "exception": "Exceeds length limit"
+      },
+      {
+        "prefix": "foobar",
+        "words": [20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+        "exception": "Exceeds length limit"
+      },
+      {
+        "prefix": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoobarfoobarfoobarfoobar",
+        "words": [128],
+        "limit": 104,
+        "exception": "Exceeds length limit"
+      },
+      {
+        "string": "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+        "exception": "Exceeds length limit"
+      },
+      {
+        "prefix": "abc\u00ff",
+        "words": [18],
+        "exception": "Invalid prefix \\(abc\u00ff\\)"
+      },
+      {
+        "string": "in1muywd",
         "exception": "Data too short"
       },
       {

--- a/test/index.js
+++ b/test/index.js
@@ -44,6 +44,17 @@ function testValidFixture (f, bech32) {
       bech32.decode(string, f.limit)
     }, new RegExp('Invalid checksum|Unknown character'))
   })
+
+  // === compare of objects compares reference in memory, so this works
+  const wrongBech32 = bech32 === bech32Lib.bech32 ? bech32Lib.bech32m : bech32Lib.bech32
+  tape(`fails for ${f.string} with wrong encoding`, (t) => {
+    t.plan(2)
+
+    t.equal(wrongBech32.decodeUnsafe(f.string, f.limit), undefined)
+    t.throws(function () {
+      wrongBech32.decode(f.string, f.limit)
+    }, new RegExp('Invalid checksum'))
+  })
 }
 
 function testInvalidFixture (f, bech32) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,15 @@
 'use strict'
-let tape = require('tape')
-let fixtures = require('./fixtures')
-let bech32 = require('../')
+const tape = require('tape')
+const fixtures = require('./fixtures')
+const bech32 = require('../')
 
 function testValidFixture (f, encoding) {
   if (f.hex) {
     tape(`fromWords/toWords ${f.hex}`, (t) => {
       t.plan(2)
 
-      let words = bech32.toWords(Buffer.from(f.hex, 'hex'))
-      let bytes = Buffer.from(bech32.fromWords(f.words))
+      const words = bech32.toWords(Buffer.from(f.hex, 'hex'))
+      const bytes = Buffer.from(bech32.fromWords(f.words))
       t.same(words, f.words)
       t.same(bytes.toString('hex'), f.hex)
     })
@@ -34,9 +34,9 @@ function testValidFixture (f, encoding) {
   tape(`fails for ${f.string} with 1 bit flipped`, (t) => {
     t.plan(2)
 
-    let buffer = Buffer.from(f.string, 'utf8')
+    const buffer = Buffer.from(f.string, 'utf8')
     buffer[f.string.lastIndexOf('1') + 1] ^= 0x1 // flip a bit, after the prefix
-    let string = buffer.toString('utf8')
+    const string = buffer.toString('utf8')
     t.equal(bech32.decodeUnsafe(string, encoding, f.limit), undefined)
     t.throws(function () {
       bech32.decode(string, encoding, f.limit)
@@ -66,7 +66,7 @@ function testInvalidFixture (f, encoding) {
   }
 
   if (f.string !== undefined || f.stringHex) {
-    let string = f.string || Buffer.from(f.stringHex, 'hex').toString('binary')
+    const string = f.string || Buffer.from(f.stringHex, 'hex').toString('binary')
 
     tape(`decode fails for ${string} (${f.exception})`, (t) => {
       t.plan(2)
@@ -104,7 +104,7 @@ fixtures.fromWords.invalid.forEach((f) => {
   })
 })
 
-tape(`toWords/toWordsUnsafe accept bytes as ArrayLike<number>`, (t) => {
+tape('toWords/toWordsUnsafe accept bytes as ArrayLike<number>', (t) => {
   // Ensures that only the two operations from
   //   interface ArrayLike<T> {
   //     readonly length: number;

--- a/test/index.js
+++ b/test/index.js
@@ -1,23 +1,25 @@
 'use strict'
 const tape = require('tape')
 const fixtures = require('./fixtures')
-const bech32 = require('../')
+const bech32Lib = require('../')
 
-function testValidFixture (f, encoding) {
+function testValidFixture (f, bech32) {
   if (f.hex) {
     tape(`fromWords/toWords ${f.hex}`, (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const words = bech32.toWords(Buffer.from(f.hex, 'hex'))
       const bytes = Buffer.from(bech32.fromWords(f.words))
+      const bytes2 = Buffer.from(bech32.fromWordsUnsafe(f.words))
       t.same(words, f.words)
       t.same(bytes.toString('hex'), f.hex)
+      t.same(bytes2.toString('hex'), f.hex)
     })
   }
 
   tape(`encode ${f.prefix} ${f.hex || f.words}`, (t) => {
     t.plan(1)
-    t.strictEqual(bech32.encode(f.prefix, f.words, encoding, f.limit), f.string.toLowerCase())
+    t.strictEqual(bech32.encode(f.prefix, f.words, f.limit), f.string.toLowerCase())
   })
 
   tape(`decode ${f.string}`, (t) => {
@@ -27,8 +29,8 @@ function testValidFixture (f, encoding) {
       prefix: f.prefix.toLowerCase(),
       words: f.words
     }
-    t.same(bech32.decodeUnsafe(f.string, encoding, f.limit), expected)
-    t.same(bech32.decode(f.string, encoding, f.limit), expected)
+    t.same(bech32.decodeUnsafe(f.string, f.limit), expected)
+    t.same(bech32.decode(f.string, f.limit), expected)
   })
 
   tape(`fails for ${f.string} with 1 bit flipped`, (t) => {
@@ -37,30 +39,20 @@ function testValidFixture (f, encoding) {
     const buffer = Buffer.from(f.string, 'utf8')
     buffer[f.string.lastIndexOf('1') + 1] ^= 0x1 // flip a bit, after the prefix
     const string = buffer.toString('utf8')
-    t.equal(bech32.decodeUnsafe(string, encoding, f.limit), undefined)
+    t.equal(bech32.decodeUnsafe(string, f.limit), undefined)
     t.throws(function () {
-      bech32.decode(string, encoding, f.limit)
+      bech32.decode(string, f.limit)
     }, new RegExp('Invalid checksum|Unknown character'))
-  })
-
-  const wrongEncoding = encoding === bech32.encodings.BECH32 ? bech32.encodings.BECH32M : bech32.encodings.BECH32
-  tape(`fails for ${f.string} with wrong encoding`, (t) => {
-    t.plan(2)
-
-    t.equal(bech32.decodeUnsafe(f.string, wrongEncoding, f.limit), undefined)
-    t.throws(function () {
-      bech32.decode(f.string, wrongEncoding, f.limit)
-    }, new RegExp('Invalid checksum'))
   })
 }
 
-function testInvalidFixture (f, encoding) {
+function testInvalidFixture (f, bech32) {
   if (f.prefix !== undefined && f.words !== undefined) {
     tape(`encode fails with (${f.exception})`, (t) => {
       t.plan(1)
 
       t.throws(function () {
-        bech32.encode(f.prefix, f.words, encoding)
+        bech32.encode(f.prefix, f.words)
       }, new RegExp(f.exception))
     })
   }
@@ -70,36 +62,36 @@ function testInvalidFixture (f, encoding) {
 
     tape(`decode fails for ${string} (${f.exception})`, (t) => {
       t.plan(2)
-      t.equal(bech32.decodeUnsafe(string, encoding), undefined)
+      t.equal(bech32.decodeUnsafe(string), undefined)
       t.throws(function () {
-        bech32.decode(string, encoding)
+        bech32.decode(string)
       }, new RegExp(f.exception))
     })
   }
 }
 
 fixtures.bech32.valid.forEach((f) => {
-  testValidFixture(f, bech32.encodings.BECH32)
+  testValidFixture(f, bech32Lib.bech32)
 })
 
 fixtures.bech32.invalid.forEach((f) => {
-  testInvalidFixture(f, bech32.encodings.BECH32)
+  testInvalidFixture(f, bech32Lib.bech32)
 })
 
 fixtures.bech32m.valid.forEach((f) => {
-  testValidFixture(f, bech32.encodings.BECH32M)
+  testValidFixture(f, bech32Lib.bech32m)
 })
 
 fixtures.bech32m.invalid.forEach((f) => {
-  testInvalidFixture(f, bech32.encodings.BECH32M)
+  testInvalidFixture(f, bech32Lib.bech32m)
 })
 
 fixtures.fromWords.invalid.forEach((f) => {
   tape(`fromWords fails with ${f.exception}`, (t) => {
     t.plan(2)
-    t.equal(bech32.fromWordsUnsafe(f.words), undefined)
+    t.equal(bech32Lib.bech32.fromWordsUnsafe(f.words), undefined)
     t.throws(function () {
-      bech32.fromWords(f.words)
+      bech32Lib.bech32.fromWords(f.words)
     }, new RegExp(f.exception))
   })
 })
@@ -121,8 +113,8 @@ tape('toWords/toWordsUnsafe accept bytes as ArrayLike<number>', (t) => {
     3: 0x33,
     4: 0xff
   }
-  const words1 = bech32.toWords(bytes)
-  const words2 = bech32.toWordsUnsafe(bytes)
+  const words1 = bech32Lib.bech32.toWords(bytes)
+  const words2 = bech32Lib.bech32.toWordsUnsafe(bytes)
   t.plan(2)
   t.same(words1, [0, 0, 8, 18, 4, 12, 31, 31])
   t.same(words2, [0, 0, 8, 18, 4, 12, 31, 31])

--- a/test/types.ts
+++ b/test/types.ts
@@ -2,41 +2,41 @@
 // When you open it in Visual Studio Code, the built-in TypeScript server should run all
 // the type checks. For manually runtime testing you can use ts-node to run this file.
 
-import * as bech32 from "..";
+import { bech32 } from "..";
 
-function encodeUint8Array(prefix: string, data: Uint8Array, encoding: bech32.Encoding): string {
-  const address = bech32.encode(prefix, bech32.toWords(data), encoding);
+function encodeUint8Array(prefix: string, data: Uint8Array): string {
+  const address = bech32.encode(prefix, bech32.toWords(data));
   return address;
 }
 
-function decodeUint8Array(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Uint8Array } {
-  const decodedAddress = bech32.decode(address, encoding);
+function decodeUint8Array(address: string): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decode(address);
   return {
     prefix: decodedAddress.prefix,
     data: new Uint8Array(bech32.fromWords(decodedAddress.words)),
   };
 }
 
-function encodeBuffer(prefix: string, data: Buffer, encoding: bech32.Encoding): string {
-  const address = bech32.encode(prefix, bech32.toWords(data), encoding);
+function encodeBuffer(prefix: string, data: Buffer): string {
+  const address = bech32.encode(prefix, bech32.toWords(data));
   return address;
 }
 
-function decodeBuffer(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Buffer } {
-  const decodedAddress = bech32.decode(address, encoding);
+function decodeBuffer(address: string): { readonly prefix: string; readonly data: Buffer } {
+  const decodedAddress = bech32.decode(address);
   return {
     prefix: decodedAddress.prefix,
     data: Buffer.from(bech32.fromWords(decodedAddress.words)),
   };
 }
 
-function encodeUnsafe(prefix: string, data: Uint8Array, encoding: bech32.Encoding): string | undefined {
-  const address = bech32.encode(prefix, bech32.toWordsUnsafe(data), encoding);
+function encodeUnsafe(prefix: string, data: Uint8Array): string | undefined {
+  const address = bech32.encode(prefix, bech32.toWordsUnsafe(data));
   return address;
 }
 
-function decodeUnsafe(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Uint8Array } {
-  const decodedAddress = bech32.decodeUnsafe(address, encoding);
+function decodeUnsafe(address: string): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decodeUnsafe(address);
   return {
     prefix: decodedAddress.prefix,
     data: new Uint8Array(bech32.fromWordsUnsafe(decodedAddress.words)),
@@ -47,25 +47,22 @@ function main(): void {
   {
     const prefix = "foo";
     const data = new Uint8Array([0x00, 0x11, 0x22]);
-    const encoding = bech32.Encoding.BECH32;
-    const address = encodeUint8Array(prefix, data, encoding);
-    const decoded = decodeUint8Array(address, encoding);
+    const address = encodeUint8Array(prefix, data);
+    const decoded = decodeUint8Array(address);
     console.log(prefix, data, address, decoded);
   }
   {
     const prefix = "foo";
     const data = Buffer.from([0x00, 0x11, 0x22]);
-    const encoding = bech32.Encoding.BECH32;
-    const address = encodeBuffer(prefix, data, encoding);
-    const decoded = decodeBuffer(address, encoding);
+    const address = encodeBuffer(prefix, data);
+    const decoded = decodeBuffer(address);
     console.log(prefix, data, address, decoded);
   }
   {
     const prefix = "foo";
     const data = new Uint8Array([0x00, 0x11, 0x22]);
-    const encoding = bech32.Encoding.BECH32;
-    const address = encodeUnsafe(prefix, data, encoding);
-    const decoded = decodeUnsafe(address, encoding);
+    const address = encodeUnsafe(prefix, data);
+    const decoded = decodeUnsafe(address);
     console.log(prefix, data, address, decoded);
   }
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -4,39 +4,39 @@
 
 import * as bech32 from "..";
 
-function encodeUint8Array(prefix: string, data: Uint8Array): string {
-  const address = bech32.encode(prefix, bech32.toWords(data));
+function encodeUint8Array(prefix: string, data: Uint8Array, encoding: bech32.Encoding): string {
+  const address = bech32.encode(prefix, bech32.toWords(data), encoding);
   return address;
 }
 
-function decodeUint8Array(address: string): { readonly prefix: string; readonly data: Uint8Array } {
-  const decodedAddress = bech32.decode(address);
+function decodeUint8Array(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decode(address, encoding);
   return {
     prefix: decodedAddress.prefix,
     data: new Uint8Array(bech32.fromWords(decodedAddress.words)),
   };
 }
 
-function encodeBuffer(prefix: string, data: Buffer): string {
-  const address = bech32.encode(prefix, bech32.toWords(data));
+function encodeBuffer(prefix: string, data: Buffer, encoding: bech32.Encoding): string {
+  const address = bech32.encode(prefix, bech32.toWords(data), encoding);
   return address;
 }
 
-function decodeBuffer(address: string): { readonly prefix: string; readonly data: Buffer } {
-  const decodedAddress = bech32.decode(address);
+function decodeBuffer(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Buffer } {
+  const decodedAddress = bech32.decode(address, encoding);
   return {
     prefix: decodedAddress.prefix,
     data: Buffer.from(bech32.fromWords(decodedAddress.words)),
   };
 }
 
-function encodeUnsafe(prefix: string, data: Uint8Array): string | undefined {
-  const address = bech32.encode(prefix, bech32.toWordsUnsafe(data));
+function encodeUnsafe(prefix: string, data: Uint8Array, encoding: bech32.Encoding): string | undefined {
+  const address = bech32.encode(prefix, bech32.toWordsUnsafe(data), encoding);
   return address;
 }
 
-function decodeUnsafe(address: string): { readonly prefix: string; readonly data: Uint8Array } {
-  const decodedAddress = bech32.decodeUnsafe(address);
+function decodeUnsafe(address: string, encoding: bech32.Encoding): { readonly prefix: string; readonly data: Uint8Array } {
+  const decodedAddress = bech32.decodeUnsafe(address, encoding);
   return {
     prefix: decodedAddress.prefix,
     data: new Uint8Array(bech32.fromWordsUnsafe(decodedAddress.words)),
@@ -47,22 +47,25 @@ function main(): void {
   {
     const prefix = "foo";
     const data = new Uint8Array([0x00, 0x11, 0x22]);
-    const address = encodeUint8Array(prefix, data);
-    const decoded = decodeUint8Array(address);
+    const encoding = bech32.Encoding.BECH32;
+    const address = encodeUint8Array(prefix, data, encoding);
+    const decoded = decodeUint8Array(address, encoding);
     console.log(prefix, data, address, decoded);
   }
   {
     const prefix = "foo";
     const data = Buffer.from([0x00, 0x11, 0x22]);
-    const address = encodeBuffer(prefix, data);
-    const decoded = decodeBuffer(address);
+    const encoding = bech32.Encoding.BECH32;
+    const address = encodeBuffer(prefix, data, encoding);
+    const decoded = decodeBuffer(address, encoding);
     console.log(prefix, data, address, decoded);
   }
   {
     const prefix = "foo";
     const data = new Uint8Array([0x00, 0x11, 0x22]);
-    const address = encodeUnsafe(prefix, data);
-    const decoded = decodeUnsafe(address);
+    const encoding = bech32.Encoding.BECH32;
+    const address = encodeUnsafe(prefix, data, encoding);
+    const decoded = decodeUnsafe(address, encoding);
     console.log(prefix, data, address, decoded);
   }
 }


### PR DESCRIPTION
This PR adds support for BIP350 bech32m encoding. The relevant test vectors are included from [here](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#Test_vectors_for_Bech32m).

Note this is a backwards incompatible change. A new `encoding` argument is required when encoding or decoding.